### PR TITLE
Issue 35 - Assignment DELETE Endpoint and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AssignmentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AssignmentsController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -68,5 +70,29 @@ public class AssignmentsController extends ApiController {
     Assignment savedAssignment = assignmentRepository.save(assignment);
 
     return savedAssignment;
+  }
+
+  @Operation(summary = "Delete an assignment")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @DeleteMapping("/{id}")
+  public Object deleteAssignment(
+      @Parameter(name = "id") @PathVariable Long id,
+      @Parameter(name = "courseId") @RequestParam Long courseId) {
+
+    // check course exists
+    courseRepository
+        .findById(courseId)
+        .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+
+    // find assignment or throw error
+    Assignment assignment =
+        assignmentRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Assignment.class, id));
+
+    // delete the assignment
+    assignmentRepository.delete(assignment);
+
+    return genericMessage(String.format("Assignment with id %s deleted", id));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/AssignmentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/AssignmentsControllerTests.java
@@ -3,10 +3,12 @@ package edu.ucsb.cs156.frontiers.controllers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -137,5 +139,81 @@ public class AssignmentsControllerTests extends ControllerTestCase {
             "message", "Course with id 1 not found");
     String expectedJson = mapper.writeValueAsString(expectedMap);
     assertEquals(expectedJson, responseString);
+  }
+
+  // DELETE endpoint tests
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/assignments/10").param("courseId", "1").with(csrf()))
+        .andExpect(status().is(403)); // forbidden
+  }
+
+  @Test
+  @WithMockUser(roles = {"USER"})
+  public void logged_in_users_without_permission_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/assignments/10").param("courseId", "1").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void instructor_can_delete_assignment() throws Exception {
+    // Arrange course
+    Course course = Course.builder().id(1L).build();
+    when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+
+    // Arrange assignment
+    Assignment assignment = Assignment.builder().id(10L).name("HW1").course(course).build();
+    when(assignmentRepository.findById(10L)).thenReturn(Optional.of(assignment));
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/assignments/10").with(csrf()).param("courseId", "1"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // Assert interactions
+    verify(courseRepository, times(1)).findById(1L);
+    verify(assignmentRepository, times(1)).findById(10L);
+    verify(assignmentRepository, times(1)).delete(assignment);
+
+    // Assert message
+    String expectedJson =
+        mapper.writeValueAsString(Map.of("message", "Assignment with id 10 deleted"));
+    assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void delete_assignment_returns_404_when_course_not_found() throws Exception {
+    when(courseRepository.findById(999L)).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(delete("/api/assignments/10").with(csrf()).param("courseId", "999"))
+        .andExpect(status().isNotFound());
+
+    verify(courseRepository, times(1)).findById(999L);
+    verify(assignmentRepository, never()).findById(any());
+    verify(assignmentRepository, never()).delete(any());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void delete_assignment_returns_404_when_assignment_not_found() throws Exception {
+    Course course = Course.builder().id(1L).build();
+    when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
+    when(assignmentRepository.findById(10L)).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(delete("/api/assignments/10").with(csrf()).param("courseId", "1"))
+        .andExpect(status().isNotFound());
+
+    verify(courseRepository, times(1)).findById(1L);
+    verify(assignmentRepository, times(1)).findById(10L);
+    verify(assignmentRepository, never()).delete(any());
   }
 }


### PR DESCRIPTION
Dokku deployment: [https://frontiers-dev-saanvi25-pr50.dokku-10.cs.ucsb.edu/](url)

To test: Go to Swagger and first create a Course using the POST endpoint for Courses. Then using the ID of the new course, use the POST endpoint for Assignments to create a new assignment. Test the DELETE endpoint by providing an assignmentId and courseId. Also try testing with invalid courseId and invalid assignmentID.

Changes: Changed the AssignmentsController and AssignmentsControllerTest files to add the DELETE endpoint functionality. 

After endpoint created: 
<img width="1195" height="325" alt="Screenshot 2025-11-25 at 2 26 32 PM" src="https://github.com/user-attachments/assets/ac60488f-e2b4-4803-aeb9-ba7b4f4e8640" />
<img width="1195" height="571" alt="Screenshot 2025-11-25 at 2 26 50 PM" src="https://github.com/user-attachments/assets/787715b1-04d4-4383-9d85-5b40085af5da" />


Closes #35 