### PR TITLE
Issue 13: Refactoring (another approach) 

### DIFF
--- a/frontend/src/main/components/Auth/SignInOptions.jsx
+++ b/frontend/src/main/components/Auth/SignInOptions.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { FaMicrosoft } from "react-icons/fa";
+import { FcGoogle } from "react-icons/fc";
+import { Row } from "react-bootstrap";
+import SignInCard from "main/components/Auth/SignInCard";
+import { useSystemInfo } from "main/utils/systemInfo";
+import loginProviderSchools from "main/utils/loginProviderSchools";
+
+const SignInOptions = ({ onSignIn }) => {
+  const { data: systemInfo } = useSystemInfo();
+
+  const microsoftIcon = () => {
+    return (
+      <span data-testid={"SignInOptions-microsoftIcon"}>
+        <FaMicrosoft size={"10em"} role={"img"} />
+      </span>
+    );
+  };
+
+  const googleIcon = () => {
+    return (
+      <span data-testid={"SignInOptions-googleIcon"}>
+        <FcGoogle size={"10em"} role={"img"} />
+      </span>
+    );
+  };
+
+  return (
+    <Row
+      xs={1}
+      md={2}
+      className={"g-5 d-flex gap-5 justify-content-center align-items-center"}
+      data-testid={"SignInOptions-cardDisplay"}
+    >
+      {systemInfo.oauthLogin && (
+        <SignInCard
+          Icon={googleIcon}
+          title={"Sign in with Google"}
+          description={
+            <>
+              If you have credentials with these schools, sign in with Google
+              <ul>
+                {loginProviderSchools.google.map((school, index) => (
+                  <li key={index}>{school}</li>
+                ))}
+              </ul>
+            </>
+          }
+          url={systemInfo.oauthLogin}
+          testid={"google"}
+          onClick={onSignIn}
+        />
+      )}
+      {systemInfo.activeDirectoryUrl && (
+        <SignInCard
+          Icon={microsoftIcon}
+          title={"Sign in with Microsoft"}
+          description={
+            <>
+              If you have credentials with these schools, sign in with Microsoft
+              <ul>
+                {loginProviderSchools.microsoft.map((school, index) => (
+                  <li key={index}>{school}</li>
+                ))}
+              </ul>
+            </>
+          }
+          url={systemInfo.activeDirectoryUrl}
+          testid={"microsoft"}
+          onClick={onSignIn}
+        />
+      )}
+    </Row>
+  );
+};
+
+export default SignInOptions;

--- a/frontend/src/main/pages/Auth/PromptSignInPage.jsx
+++ b/frontend/src/main/pages/Auth/PromptSignInPage.jsx
@@ -1,31 +1,9 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { FaMicrosoft } from "react-icons/fa";
-import { FcGoogle } from "react-icons/fc";
 import { Alert, Row } from "react-bootstrap";
-import SignInCard from "main/components/Auth/SignInCard";
-import { useSystemInfo } from "main/utils/systemInfo";
 import { useLocation } from "react-router";
-import loginProviderSchools from "main/utils/loginProviderSchools";
+import SignInOptions from "main/components/Auth/SignInOptions";
 
 export default function PromptSignInPage() {
-  const microsoftIcon = () => {
-    return (
-      <span data-testid={"SignInPage-microsoftIcon"}>
-        <FaMicrosoft size={"10em"} role={"img"} />
-      </span>
-    );
-  };
-
-  const { data: systemInfo } = useSystemInfo();
-
-  const googleIcon = () => {
-    return (
-      <span data-testid={"SignInPage-googleIcon"}>
-        <FcGoogle size={"10em"} role={"img"} />
-      </span>
-    );
-  };
-
   const location = useLocation();
 
   const setRedirect = () => {
@@ -39,52 +17,7 @@ export default function PromptSignInPage() {
           Please sign in before accessing this page.
         </Alert>
       </Row>
-      <Row
-        xs={1}
-        md={2}
-        className={"g-5 d-flex gap-5 justify-content-center align-items-center"}
-        data-testid={"SignInPage-cardDisplay"}
-      >
-        {systemInfo.oauthLogin && (
-          <SignInCard
-            Icon={googleIcon}
-            title={"Sign in with Google"}
-            description={
-              <>
-                If you have credentials with these schools, sign in with Google
-                <ul>
-                  {loginProviderSchools.google.map((school, index) => (
-                    <li key={index}>{school}</li>
-                  ))}
-                </ul>
-              </>
-            }
-            url={systemInfo.oauthLogin}
-            testid={"google"}
-            onClick={setRedirect}
-          />
-        )}
-        {systemInfo.activeDirectoryUrl && (
-          <SignInCard
-            Icon={microsoftIcon}
-            title={"Sign in with Microsoft"}
-            description={
-              <>
-                If you have credentials with these schools, sign in with
-                Microsoft
-                <ul>
-                  {loginProviderSchools.microsoft.map((school, index) => (
-                    <li key={index}>{school}</li>
-                  ))}
-                </ul>
-              </>
-            }
-            url={systemInfo.activeDirectoryUrl}
-            testid={"microsoft"}
-            onClick={setRedirect}
-          />
-        )}
-      </Row>
+      <SignInOptions onSignIn={setRedirect} />
     </BasicLayout>
   );
 }

--- a/frontend/src/main/pages/Auth/SignInPage.jsx
+++ b/frontend/src/main/pages/Auth/SignInPage.jsx
@@ -1,76 +1,10 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { FaMicrosoft } from "react-icons/fa";
-import { FcGoogle } from "react-icons/fc";
-import { Row } from "react-bootstrap";
-import SignInCard from "main/components/Auth/SignInCard";
-import { useSystemInfo } from "main/utils/systemInfo";
-import loginProviderSchools from "main/utils/loginProviderSchools";
+import SignInOptions from "main/components/Auth/SignInOptions";
 
 export default function SignInPage() {
-  const microsoftIcon = () => {
-    return (
-      <span data-testid={"SignInPage-microsoftIcon"}>
-        <FaMicrosoft size={"10em"} role={"img"} />
-      </span>
-    );
-  };
-
-  const { data: systemInfo } = useSystemInfo();
-
-  const googleIcon = () => {
-    return (
-      <span data-testid={"SignInPage-googleIcon"}>
-        <FcGoogle size={"10em"} role={"img"} />
-      </span>
-    );
-  };
-
   return (
     <BasicLayout>
-      <Row
-        xs={1}
-        md={2}
-        className={"g-5 d-flex gap-5 justify-content-center align-items-center"}
-        data-testid={"SignInPage-cardDisplay"}
-      >
-        {systemInfo.oauthLogin && (
-          <SignInCard
-            Icon={googleIcon}
-            title={"Sign in with Google"}
-            description={
-              <>
-                If you have credentials with these schools, sign in with Google
-                <ul>
-                  {loginProviderSchools.google.map((school, index) => (
-                    <li key={index}>{school}</li>
-                  ))}
-                </ul>
-              </>
-            }
-            url={systemInfo.oauthLogin}
-            testid={"google"}
-          />
-        )}
-        {systemInfo.activeDirectoryUrl && (
-          <SignInCard
-            Icon={microsoftIcon}
-            title={"Sign in with Microsoft"}
-            description={
-              <>
-                If you have credentials with these schools, sign in with
-                Microsoft
-                <ul>
-                  {loginProviderSchools.microsoft.map((school, index) => (
-                    <li key={index}>{school}</li>
-                  ))}
-                </ul>
-              </>
-            }
-            url={systemInfo.activeDirectoryUrl}
-            testid={"microsoft"}
-          />
-        )}
-      </Row>
+      <SignInOptions />
     </BasicLayout>
   );
 }

--- a/frontend/src/stories/components/Auth/SignInOptions.stories.jsx
+++ b/frontend/src/stories/components/Auth/SignInOptions.stories.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import SignInOptions from "main/components/Auth/SignInOptions";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/Auth/SignInOptions",
+  component: SignInOptions,
+};
+
+const Template = (args) => <SignInOptions {...args} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+    ],
+  },
+};
+
+export const WithGoogle = Template.bind({});
+WithGoogle.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingBoth, {
+          status: 200,
+        });
+      }),
+    ],
+  },
+};
+
+export const WithMicrosoft = Template.bind({});
+WithMicrosoft.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.withActiveDirectory, {
+          status: 200,
+        });
+      }),
+    ],
+  },
+};
+
+export const WithBoth = Template.bind({});
+WithBoth.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(
+          systemInfoFixtures.withActiveDirectoryAndGoogle,
+          {
+            status: 200,
+          },
+        );
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/components/Auth/SignInOptions.test.jsx
+++ b/frontend/src/tests/components/Auth/SignInOptions.test.jsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SignInOptions from "main/components/Auth/SignInOptions";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { vi } from "vitest";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("SignInOptions tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    queryClient.clear();
+  });
+
+  test("renders correctly with no login options", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SignInOptions />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("SignInOptions-cardDisplay")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with Google")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Sign in with Microsoft"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders correctly with Google login", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingBoth);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SignInOptions />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Sign in with Google");
+    expect(screen.getByTestId("SignInOptions-googleIcon")).toBeInTheDocument();
+  });
+
+  test("renders correctly with Microsoft login", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.withActiveDirectory);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SignInOptions />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Sign in with Microsoft");
+    expect(
+      screen.getByTestId("SignInOptions-microsoftIcon"),
+    ).toBeInTheDocument();
+  });
+
+  test("calls onSignIn when Google button is clicked", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingBoth);
+    const onSignIn = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SignInOptions onSignIn={onSignIn} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Sign in with Google");
+    const googleButton = screen
+      .getByTestId("SignInCard-base-google")
+      .querySelector("a");
+    fireEvent.click(googleButton);
+
+    expect(onSignIn).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/pages/Auth/PromptSignInPage.test.jsx
+++ b/frontend/src/tests/pages/Auth/PromptSignInPage.test.jsx
@@ -32,7 +32,7 @@ describe("SignInPage Tests", () => {
     );
 
     await screen.findByText("Sign in with Google");
-    expect(screen.getByTestId("SignInPage-googleIcon")).toBeInTheDocument();
+    expect(screen.getByTestId("SignInOptions-googleIcon")).toBeInTheDocument();
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -66,7 +66,9 @@ describe("SignInPage Tests", () => {
       </QueryClientProvider>,
     );
     await screen.findByText("Sign in with Microsoft");
-    expect(screen.getByTestId("SignInPage-microsoftIcon")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("SignInOptions-microsoftIcon"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("SignInCard-base-microsoft")).toBeInTheDocument();
     expect(screen.getByText("Sign in with Microsoft")).toBeInTheDocument();
     expect(
@@ -94,7 +96,7 @@ describe("SignInPage Tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByTestId("SignInPage-cardDisplay")).toHaveClass(
+    expect(screen.getByTestId("SignInOptions-cardDisplay")).toHaveClass(
       "g-5 justify-content-center align-items-center",
       "d-flex",
       "gap-5",

--- a/frontend/src/tests/pages/Auth/SignInPage.test.jsx
+++ b/frontend/src/tests/pages/Auth/SignInPage.test.jsx
@@ -32,7 +32,7 @@ describe("SignInPage Tests", () => {
     );
 
     await screen.findByText("Sign in with Google");
-    expect(screen.getByTestId("SignInPage-googleIcon")).toBeInTheDocument();
+    expect(screen.getByTestId("SignInOptions-googleIcon")).toBeInTheDocument();
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -62,7 +62,9 @@ describe("SignInPage Tests", () => {
       </QueryClientProvider>,
     );
     await screen.findByText("Sign in with Microsoft");
-    expect(screen.getByTestId("SignInPage-microsoftIcon")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("SignInOptions-microsoftIcon"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("SignInCard-base-microsoft")).toBeInTheDocument();
     expect(screen.getByText("Sign in with Microsoft")).toBeInTheDocument();
     expect(
@@ -90,7 +92,7 @@ describe("SignInPage Tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByTestId("SignInPage-cardDisplay")).toHaveClass(
+    expect(screen.getByTestId("SignInOptions-cardDisplay")).toHaveClass(
       "g-5 justify-content-center align-items-center",
       "d-flex",
       "gap-5",


### PR DESCRIPTION
# Deployment  

You can test at https://frontiers-dev-kham-arun-pr47.dokku-10.cs.ucsb.edu/
please ignore url name (reuse old stuff)

# Changes Made  
In this PR, I refactored in a different way from another PR21 by adding a new component called `SignInOptions` that is called by both `SignInPage` and `PromptSignInPage`. This will make the code look clean and avoid future scenario of one component handling multiple things (God Component).
### 1. New Component: `SignInOptions`
Created `frontend/src/main/components/Auth/SignInOptions.jsx` to encapsulate the logic for displaying Google and Microsoft sign-in cards and:
- Handles `useSystemInfo`.
- Defines the icons (`FaMicrosoft`, `FcGoogle`).
- Accepts an optional `onSignIn` for click handling.
### 2. Refactored Pages
Removed lines of duplicate code from each of these pages:
- `SignInPage.jsx`: Now simply renders `SignInOptions`.
- `PromptSignInPage.jsx`: Now renders `SignInOptions` with `onSignIn={setRedirect}`, preserving its unique redirect logic.
### 3. Tests & Stories
- New Test: `frontend/src/tests/components/Auth/SignInOptions.test.jsx`
- Updated Test id in: `SignInPage.test.jsx` and `PromptSignInPage.test.jsx`
- New Story: `frontend/src/stories/components/Auth/SignInOptions.stories.jsx`

# Related Issue
closes #13
